### PR TITLE
Update names so they all begin with 'Kong'

### DIFF
--- a/afk_command.user.js
+++ b/afk_command.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           AFK Command
+// @name           Kongregate AFK Command
 // @namespace      tag://kongregate
 // @description    Adds an /afk-command to Kongregate's chat, which will flag you as afk. When flagged as afk, you automatically send a notice to the user who whispered you.
 // @include        http://www.kongregate.com/games/*

--- a/challenge_notification_remover.user.js
+++ b/challenge_notification_remover.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name          Challenge Notification Remover for Kongregate Chat
+// @name          Kongregate Chat Challenge Notification Remover
 // @namespace     ventero.de
 // @include       http://www.kongregate.com/games/*
 // @description   This script removes the challenge notification in Kongregate's Chat

--- a/characterlimit.user.js
+++ b/characterlimit.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           Character Limit
+// @name           Kongregate Chat Character Limit
 // @namespace      tag://kongregate
 // @description    Limits your textinput to 250 characters
 // @include        http://www.kongregate.com/games/*

--- a/chat_resizer.user.js
+++ b/chat_resizer.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name            Chat Resizer
+// @name            Kongregate Chat Resizer
 // @namespace       tag://kongregate
 // @description     Automatically resizes the chat to a specified value. This value can be overriden for single games.
 // @author          Ventero

--- a/clickable_links.user.js
+++ b/clickable_links.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           Clickable Links
+// @name           Kongregate Chat Clickable Links
 // @namespace      ventero.de
 // @description    Makes all links in chat clickable
 // @include        http://www.kongregate.com/games/*

--- a/clickable_links.user.js
+++ b/clickable_links.user.js
@@ -8,6 +8,7 @@
 // @version        1.2
 // @grant          none
 // @require        http://kong.ventero.de/require.js
+// @require        http://gregjacobs.github.io/Autolinker.js/dist/Autolinker.min.js
 // ==/UserScript==
 
 // Written by Ventero (http://www.kongregate.com/accounts/Ventero) 08/08/2010
@@ -15,16 +16,35 @@
 // Copyright (c) 2010 Ventero
 // http://www.opensource.org/licenses/mit-license.php
 
+var autolinker = new Autolinker( {
+    urls : {
+        schemeMatches : true,
+        wwwMatches    : true,
+        tldMatches    : true
+    },
+    email       : false,
+    phone       : false,
+    twitter     : false,
+    hashtag     : false,
+
+    stripPrefix : true,
+    newWindow   : true,
+
+    truncate : {
+        length   : 30,
+        location : 'smart'
+    },
+
+    className : ''
+} );
+
 function init_clickable_links(){
   if(typeof holodeck !== "undefined" && !holodeck.__urlregex){
     holodeck.__urlregex = true;
     // more or less rfc3986 compliant (probably too lenient on what it matches)
-    var urlregex = /\b((?:(?:((?:ht|f)tps?)\:\/\/(\w+:\w+@)?)|(?:www\.))((?:[\w-.]+\.\w{2,6})|(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))(:\d{1,5})?((\/(?:(?:[\w\/;:@&=$-.+~!*(),])|(?:%[a-f0-9]{2}))*)(\?(?:(?:[\w\/;:@&=$-.+~!*(),?])|(?:%[a-f0-9]{2}))*)?(#(?:(?:[\w\/;:@&=$-.+~!*(),?])|(?:%[a-f0-9]{2}))*)?)?)(?![^<]+<\/a>)/gi;
     holodeck.addIncomingMessageFilter(function(message, nextFunction){
-      nextFunction(message.replace(urlregex, function(a){
-        return '<a href="'+(arguments[2]?a:"http://"+a)+'">'+a+'</a>';
-      }), nextFunction);
-    })
+      nextFunction(autolinker.link(message), nextFunction);
+    });
   }
 }
 

--- a/delete_friend.user.js
+++ b/delete_friend.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name          Delete Friend Link for Kongregate
+// @name          Kongregate Delete Friend Link
 // @namespace     ventero.de
 // @description   Adds a "delete friend"-link to each of your friends' profiles.
 // @include       http://www.kongregate.com/accounts/*

--- a/fullscreen_chat.user.js
+++ b/fullscreen_chat.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name            Fullscreen Chat
+// @name            Kongregate Fullscreen Chat
 // @namespace       tag://kongregate
 // @description     Adds a chat action which hides the game and makes the chat use the available free space
 // @author          Ventero

--- a/highlighting_extended.user.js
+++ b/highlighting_extended.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           Extended Chat Line Highlighting
+// @name           Kongregate Extended Chat Line Highlighting
 // @namespace      ventero.de
 // @include        http://www.kongregate.com/games/*
 // @version        0.3.0

--- a/inchat_timestamp.user.js
+++ b/inchat_timestamp.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           In-Chat Timestamp
+// @name           Kongregate In-Chat Timestamp
 // @namespace      tag://kongregate
 // @description    Adds a timestamp to every message (format: "[01:23:34 AM] user: message"). You can change the format with /timeformat 12 or 24 to 12/24-hour-clock. /tscolor hexcode changes color of timestamp. /toggleseconds
 // @include        http://www.kongregate.com/games/*

--- a/mostplayed.user.js
+++ b/mostplayed.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name          Most played
+// @name          Kongregate Chat Most played
 // @namespace     ventero.de
 // @include       http://www.kongregate.com/games/*
 // @description   /mp #number lists the mostplayed games in the room

--- a/reply_command.user.js
+++ b/reply_command.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           Reply Command
+// @name           Kongregate Chat Reply Command
 // @namespace      tag://kongregate
 // @description    Adds a /r-command for Kongregate's chat which automatically replaces with "/w <Last user who sent you a whisper>" when pressing space. If you didn't receive a whisper yet, it gets replaced by "/w "
 // @include        http://www.kongregate.com/games/*

--- a/reply_hotkey.user.js
+++ b/reply_hotkey.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           Reply Command (hotkey)
+// @name           Kongregate Chat Reply Command (hotkey)
 // @namespace      tag://kongregate
 // @description    Inserts the username of the last user who whispered you when pressing Alt-R
 // @include        http://www.kongregate.com/games/*

--- a/username_completion.user.js
+++ b/username_completion.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name           Username-completion
+// @name           Kongregate Chat Username-completion
 // @namespace      tag://kongregate
 // @description    When pressing tab, this script replaces the current word with the first user in the userlist whose name starts with that word. Pressing tab again selects the next user etc.
 // @include        http://www.kongregate.com/games/*


### PR DESCRIPTION
I have a crapload of (mostly disabled/unfinished) scripts in
tampermonkey. This makes toggling all scripts for X website from inside
the tampermonkey interface difficult. This way, however, it's simple
enough to just sort by name and then they're all in one place.
